### PR TITLE
Up version of eslint-typescript-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-ui/build-config",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Version-controlled build config for easy re-use and sharing",
   "scripts": {
     "lint": "beemo eslint .",
@@ -75,6 +75,6 @@
     "react-dom": "^16.4.1",
     "react-test-renderer": "^16.4.1",
     "typescript": "^3.1.6",
-    "typescript-eslint-parser": "^21.0.1"
+    "typescript-eslint-parser": "^21.0.2"
   }
 }


### PR DESCRIPTION
Ver21.0.1 of eslint-typescript-parser version has a bug that prevented it from linting typescript files correctly. https://github.com/eslint/typescript-eslint-parser/issues/553 Update it to ver21.0.2 which contains a fix. Also update the version of build-config.
@williaster 