### PR TITLE
Set babel-minify builtIn=false

### DIFF
--- a/configs/babel.js
+++ b/configs/babel.js
@@ -46,7 +46,8 @@ if (args.minify) {
     "minify",
     {
       removeUndefined: false,
-      evaluate: false
+      evaluate: false,
+      builtIns: false,
     }
   ]);
 }


### PR DESCRIPTION
I ran into this `Error: Couldn't find intersection` when compiling `@superset-ui/legacy-*`

Seeing the details on this issue and try setting `builtIns:false` fixes the problem.
https://github.com/babel/minify/issues/904

More on `builtIns` and what it does
https://github.com/babel/minify/tree/master/packages/babel-plugin-minify-builtins